### PR TITLE
Changed: Represent solution gradients by Vec3 in norm integration

### DIFF
--- a/ThermoElastic/ThermoElasticity.C
+++ b/ThermoElastic/ThermoElasticity.C
@@ -77,7 +77,7 @@ bool ThermoElasticity::formInitStrainForces (ElmMats& elMat, const Vector& N,
   eps = this->getThermalStrain(elMat.vec.back(),N,X)*detJW;
 
   // Stresses due to thermal expansion
-  Vector sigma0;
+  RealArray sigma0;
   if (!C.multiply(eps,sigma0))
     return false;
 


### PR DESCRIPTION
and some `Vector` --> `RealArray` for temporaries.
The use of `Vec3` instead of `Vector` in the norm integration for `HeatEquation` is natural since the fields involved is the gradient of the primary scalar field and will always have size `nsd`. The use of Vector is then unnecessary. The performance gain is probably minimal though, but the changes are needed when we soon refactor `utl::vector` to not inherit `std::vector`.